### PR TITLE
"Flemish" --> "Dutch (Belgium)"

### DIFF
--- a/main/en/languages.json
+++ b/main/en/languages.json
@@ -407,7 +407,7 @@
           "niu": "Niuean",
           "njo": "Ao Naga",
           "nl": "Dutch",
-          "nl-BE": "Flemish",
+          "nl-BE": "Dutch (Belgium)",
           "nmg": "Kwasio",
           "nn": "Norwegian Nynorsk",
           "nnh": "Ngiemboon",


### PR DESCRIPTION
While many people use "Flemish" to refer to the Dutch spoken in Belgium, the official language is still called Dutch. 

* Flemish is a regional adjective
* Dutch is the language

https://en.wikipedia.org/wiki/Dutch_in_Belgium